### PR TITLE
fix(style): correct border

### DIFF
--- a/src/app/chat/chat-widget/chat-widget.component.css
+++ b/src/app/chat/chat-widget/chat-widget.component.css
@@ -21,9 +21,14 @@
   box-shadow: 0 5px 40px rgba(0, 0, 0, 0.16);
   background: #1976d2;
   border-radius: 50%;
+  border: none;
   outline: none;
   color: #fff;
   font-size: 32px;
+}
+
+.chat-button:focus {
+  border: 2px solid white;
 }
 
 .chat-box {


### PR DESCRIPTION
This is quite noticeable on Safari, where the default style is unsightly:

<img width="78" alt="screen shot 2018-05-02 at 08 44 31" src="https://user-images.githubusercontent.com/6270048/39509077-33154abe-4de5-11e8-828d-b1cf23416d40.png">


Also added a focus style, but wasn't too sure about the color. White isn't super visible, but the change in size is. Feel free to suggest a change there.